### PR TITLE
Moves the elastic profile element down under the job

### DIFF
--- a/pipeline.gocd.yaml
+++ b/pipeline.gocd.yaml
@@ -8,9 +8,9 @@ pipelines:
         git: https://github.com/ThoughtWorksInc/ci-workshop-app.git
     stages:
       - build: # name of stage
-          elastic_profile_id: demo-app
           jobs:
             build: # name of the job
+              elastic_profile_id: demo-app
               tasks:
                - exec: # indicates type of task
                    command: echo "hello world"


### PR DESCRIPTION
Hi David, sending you a PR with the fix. The elastic_profile_id element needs to be under a job, not a stage. 

I have also created an issue for the YAML plugin to introduce schema validation - https://github.com/tomzo/gocd-yaml-config-plugin/issues/113

I'll also fix the documentation, I agree this feature is not well documented. 